### PR TITLE
Avoid corrupting database on write failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,15 @@ module.exports = function (filename) {
   var write = low(function (writeState, cb) {
     var payload = JSON.stringify(writeState, null, '  ')
     debug('writing', filename, payload)
-    fs.writeFile(filename, payload, cb)
+    var tmpname = filename + '.' + Math.random();
+    fs.writeFile(tmpname, payload, function(err) {
+      if(err) {
+        return fs.unlink(tmpname, function () {
+          cb(err);
+        });
+      }
+      fs.rename(tmpname, filename, cb);
+    })
   })
 
   return {


### PR DESCRIPTION
If a write fails (i.e. process crashes) mid-write, protect against corrupting the database file.