### PR TITLE
support custom fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (filename) {
   // in memory copy of latest state that functions below mutate
   var state = {}
   var db = parse(filename)
-  var writeTemp = (typeof filename === 'string') // TODO: ? option
+  var writeTemp = (typeof filename === 'string') // Only use temp for regular fs. Could expose as option
 
   // `low` ensures if write is called multiple times at once the last one will be executed
   // last and call the callback. this works OK because we have `state` above
@@ -15,10 +15,9 @@ module.exports = function (filename) {
     var payload = JSON.stringify(writeState, null, '  ') // pretty printed
     debug('writing', db.name, payload)
 
-    // write to tempfile first so we know it fully writes to disk and doesnt corrupt existing file
-    var tmpname = db.name + '.' + Math.random()
-
     if (writeTemp) {
+      // write to tempfile first so we know it fully writes to disk and doesnt corrupt existing file
+      var tmpname = db.name + '.' + Math.random()
       db.fs.writeFile(tmpname, payload, function (err) {
         if (err) {
           return db.fs.unlink(tmpname, function () {

--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,13 @@ db.delete(key, function (err) {
   // deletes `key` key from data.json
 })
 ```
+
+### Custom FS
+
+```js
+
+// pass the name and custom fs
+var db = toilet({fs: customFs, name: './data.json'})
+
+// write/read as normal
+```


### PR DESCRIPTION
Adds support for custom fs. Does not break current API.

```js
var db = toiletdb({name: 'file.json', fs: archive})

// db.write etc
```

I wasn't sure about if we wanted to include the writing of a temporary file for the custom fs. For example, it doesn't seem like in hyperdrive we'd want to write a temporary file. Thoughts?